### PR TITLE
Use codecov.io instead of Coveralls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,11 @@ jobs:
           name: Install TypeScript@2.4
           command: yarn add typescript@2.4
       - run:
-          name: Test
-          command: yarn test
+          name: Test with Coverage
+          command: yarn coverage
+      - run:
+          name: Report code coverage
+          command: yarn report-coverage
   test@2.6:
     docker:
       - image: circleci/node:8
@@ -74,8 +77,11 @@ jobs:
           name: Install TypeScript@2.6
           command: yarn add typescript@2.6
       - run:
-          name: Test
-          command: yarn test
+          name: Test with Coverage
+          command: yarn coverage
+      - run:
+          name: Report code coverage
+          command: yarn report-coverage
   test@next:
     docker:
       - image: circleci/node:latest
@@ -89,8 +95,11 @@ jobs:
           name: Install TypeScript@next
           command: yarn add typescript@next
       - run:
-          name: Test
-          command: yarn test
+          name: Test with Coverage
+          command: yarn coverage
+      - run:
+          name: Report code coverage
+          command: yarn report-coverage
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,11 +41,20 @@ jobs:
       - restore_cache:
           key: dependency-cache-{{ checksum "yarn.lock" }}
       - run:
-          name: Test with Coverage
-          command: yarn coverage
+          name: Unit Tests
+          command: |
+            yarn coverage test:api
+            yarn report-coverage -F unit
       - run:
-          name: Report code coverage
-          command: yarn report-coverage
+          name: Integration Tests
+          command: |
+            yarn coverage test:integration
+            yarn report-coverage -F integration
+      - run:
+          name: Rules Tests
+          command: |
+            yarn coverage test:rules
+            yarn report-coverage -F rules
   test@2.4:
     docker:
       - image: circleci/node:6
@@ -59,11 +68,20 @@ jobs:
           name: Install TypeScript@2.4
           command: yarn add typescript@2.4
       - run:
-          name: Test with Coverage
-          command: yarn coverage
+          name: Unit Tests
+          command: |
+            yarn coverage test:api
+            yarn report-coverage -F unit
       - run:
-          name: Report code coverage
-          command: yarn report-coverage
+          name: Integration Tests
+          command: |
+            yarn coverage test:integration
+            yarn report-coverage -F integration
+      - run:
+          name: Rules Tests
+          command: |
+            yarn coverage test:rules
+            yarn report-coverage -F rules
   test@2.6:
     docker:
       - image: circleci/node:8
@@ -77,11 +95,20 @@ jobs:
           name: Install TypeScript@2.6
           command: yarn add typescript@2.6
       - run:
-          name: Test with Coverage
-          command: yarn coverage
+          name: Unit Tests
+          command: |
+            yarn coverage test:api
+            yarn report-coverage -F unit
       - run:
-          name: Report code coverage
-          command: yarn report-coverage
+          name: Integration Tests
+          command: |
+            yarn coverage test:integration
+            yarn report-coverage -F integration
+      - run:
+          name: Rules Tests
+          command: |
+            yarn coverage test:rules
+            yarn report-coverage -F rules
   test@next:
     docker:
       - image: circleci/node:latest
@@ -95,11 +122,20 @@ jobs:
           name: Install TypeScript@next
           command: yarn add typescript@next
       - run:
-          name: Test with Coverage
-          command: yarn coverage
+          name: Unit Tests
+          command: |
+            yarn coverage test:api
+            yarn report-coverage -F unit
       - run:
-          name: Report code coverage
-          command: yarn report-coverage
+          name: Integration Tests
+          command: |
+            yarn coverage test:integration
+            yarn report-coverage -F integration
+      - run:
+          name: Rules Tests
+          command: |
+            yarn coverage test:rules
+            yarn report-coverage -F rules
 
 workflows:
   version: 2

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,14 @@
+codecov:
+  ci:
+    - !test@next
+comment: false
+coverage:
+  range: "75...100"
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: "0.2%"
+    patch: false
+    changes: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,6 @@
 codecov:
-  ci:
-    - !test@next
+  notify:
+    require_ci_to_pass: false
 comment: false
 coverage:
   range: "75...100"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Pluggable TypeScript and JavaScript linter
 [![Greenkeeper badge](https://badges.greenkeeper.io/ajafff/wotan.svg)](https://greenkeeper.io/)
 [![CircleCI](https://circleci.com/gh/ajafff/wotan/tree/master.svg?style=shield)](https://circleci.com/gh/ajafff/wotan/tree/master)
 [![Build status](https://ci.appveyor.com/api/projects/status/qjfv36mtmj6m55ya/branch/master?svg=true)](https://ci.appveyor.com/project/ajafff/wotan/branch/master)
-[![Coverage Status](https://coveralls.io/repos/github/ajafff/wotan/badge.svg?branch=master)](https://coveralls.io/github/ajafff/wotan?branch=master)
+[![codecov](https://codecov.io/gh/ajafff/wotan/branch/master/graph/badge.svg)](https://codecov.io/gh/ajafff/wotan)
 
 ## What is this all about?
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,5 +15,9 @@ build: off
 test_script:
   - yarn compile
   - yarn lint
-  - yarn coverage
-  - yarn report-coverage
+  - yarn coverage test:api
+  - yarn report-coverage -F unit
+  - yarn coverage test:integration
+  - yarn report-coverage -F integration
+  - yarn coverage test:rules
+  - yarn report-coverage -F rules

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,5 @@ build: off
 test_script:
   - yarn compile
   - yarn lint
-  - yarn test:api
-  - yarn test:rules
-  - yarn test:integration
+  - yarn coverage
+  - yarn report-coverage

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:integration": "node src/cli test 'test/integration/**/*.test.json' --exact",
     "test:rules": "node src/cli test 'test/rules/**/*.test.json' --exact",
     "test:coverage": "nyc run-s test",
-    "coverage": "nyc run-s",
+    "coverage": "nyc --cache run-s",
     "report-coverage": "codecov",
     "verify": "npm-run-all -s clean -p compile lint:tslint -p check-dependencies lint:wotan test:coverage",
     "check-dependencies": "depcruise src/**/*.js bin test/conformance/*.js -v .dependency-cruiser.json"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:integration": "node src/cli test 'test/integration/**/*.test.json' --exact",
     "test:rules": "node src/cli test 'test/rules/**/*.test.json' --exact",
     "coverage": "nyc run-s test",
-    "report-coverage": "cat ./coverage/lcov.info | coveralls",
+    "report-coverage": "codecov",
     "verify": "npm-run-all -s clean -p compile lint:tslint -p check-dependencies lint:wotan coverage",
     "check-dependencies": "depcruise src/**/*.js bin test/conformance/*.js -v .dependency-cruiser.json"
   },
@@ -55,6 +55,7 @@
     "@types/semver": "^5.4.0",
     "@types/to-absolute-glob": "^2.0.0",
     "ava": "^0.24.0",
+    "codecov": "^3.0.0",
     "coveralls": "^3.0.0",
     "dependency-cruiser": "^2.10.1",
     "escape-string-regexp": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "test:api": "ava test/conformance -v --snapshot-dir baselines",
     "test:integration": "node src/cli test 'test/integration/**/*.test.json' --exact",
     "test:rules": "node src/cli test 'test/rules/**/*.test.json' --exact",
-    "coverage": "nyc run-s test",
+    "test:coverage": "nyc run-s test",
+    "coverage": "nyc run-s",
     "report-coverage": "codecov",
-    "verify": "npm-run-all -s clean -p compile lint:tslint -p check-dependencies lint:wotan coverage",
+    "verify": "npm-run-all -s clean -p compile lint:tslint -p check-dependencies lint:wotan test:coverage",
     "check-dependencies": "depcruise src/**/*.js bin test/conformance/*.js -v .dependency-cruiser.json"
   },
   "repository": {
@@ -56,7 +57,6 @@
     "@types/to-absolute-glob": "^2.0.0",
     "ava": "^0.24.0",
     "codecov": "^3.0.0",
-    "coveralls": "^3.0.0",
     "dependency-cruiser": "^2.10.1",
     "escape-string-regexp": "^1.0.5",
     "npm-run-all": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,15 +152,6 @@ ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.1.0:
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.1.tgz#b38bb8876d9e86bee994956a04e721e88b248eb2"
-  dependencies:
-    co "^4.6.0"
-    fast-deep-equal "^1.0.0"
-    fast-json-stable-stringify "^2.0.0"
-    json-schema-traverse "^0.3.0"
-
 align-text@^0.1.1, align-text@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/align-text/-/align-text-0.1.4.tgz#0cd90a561093f35d0a99256c22b7069433fad117"
@@ -425,11 +416,7 @@ aws-sign2@~0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
 
-aws-sign2@~0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
-
-aws4@^1.2.1, aws4@^1.6.0:
+aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
@@ -761,18 +748,6 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-boom@4.x.x:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-4.3.1.tgz#4f8a3005cb4a7e3889f749030fd25b96e01d2e31"
-  dependencies:
-    hoek "4.x.x"
-
-boom@5.x.x:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
-  dependencies:
-    hoek "4.x.x"
-
 boxen@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-1.3.0.tgz#55c6c39a8ba58d9c61ad22cd877532deb665a20b"
@@ -1067,16 +1042,6 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-coveralls@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.0.tgz#22ef730330538080d29b8c151dc9146afde88a99"
-  dependencies:
-    js-yaml "^3.6.1"
-    lcov-parse "^0.0.10"
-    log-driver "^1.2.5"
-    minimist "^1.2.0"
-    request "^2.79.0"
-
 create-error-class@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
@@ -1103,12 +1068,6 @@ cryptiles@2.x.x:
   resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
   dependencies:
     boom "2.x.x"
-
-cryptiles@3.x.x:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-3.1.2.tgz#a89fbb220f5ce25ec56e8c4aa8a4fd7b5b0d29fe"
-  dependencies:
-    boom "5.x.x"
 
 crypto-random-string@^1.0.0:
   version "1.0.0"
@@ -1350,7 +1309,7 @@ extend-shallow@^2.0.1:
   dependencies:
     is-extendable "^0.1.0"
 
-extend@~3.0.0, extend@~3.0.1:
+extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
@@ -1461,14 +1420,6 @@ forever-agent@~0.6.1:
 form-data@~2.1.1:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.5"
-    mime-types "^2.1.12"
-
-form-data@~2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
@@ -1627,23 +1578,12 @@ har-schema@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
 
-har-schema@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
-
 har-validator@~4.2.1:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
   dependencies:
     ajv "^4.9.1"
     har-schema "^1.0.5"
-
-har-validator@~5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
-  dependencies:
-    ajv "^5.1.0"
-    har-schema "^2.0.0"
 
 has-ansi@^2.0.0:
   version "2.0.0"
@@ -1686,22 +1626,9 @@ hawk@3.1.3, hawk@~3.1.3:
     hoek "2.x.x"
     sntp "1.x.x"
 
-hawk@~6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-6.0.2.tgz#af4d914eb065f9b5ce4d9d11c1cb2126eecc3038"
-  dependencies:
-    boom "4.x.x"
-    cryptiles "3.x.x"
-    hoek "4.x.x"
-    sntp "2.x.x"
-
 hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
-
-hoek@4.x.x:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -1719,14 +1646,6 @@ http-signature@~1.1.0:
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
   dependencies:
     assert-plus "^0.2.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
-
-http-signature@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
-  dependencies:
-    assert-plus "^1.0.0"
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
@@ -2095,7 +2014,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.10.0, js-yaml@^3.6.1, js-yaml@^3.8.2:
+js-yaml@^3.10.0, js-yaml@^3.8.2:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -2187,10 +2106,6 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-lcov-parse@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
-
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -2261,10 +2176,6 @@ lodash.merge@^4.6.0:
 lodash@4.17.4, lodash@^4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
-log-driver@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.5.tgz#7ae4ec257302fd790d557cb10c97100d857b0056"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -2383,7 +2294,7 @@ mime-db@~1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
 
-mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.7:
+mime-types@^2.1.12, mime-types@~2.1.7:
   version "2.1.17"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
   dependencies:
@@ -2541,7 +2452,7 @@ nyc@^11.3.0:
     yargs "^10.0.3"
     yargs-parser "^8.0.0"
 
-oauth-sign@~0.8.1, oauth-sign@~0.8.2:
+oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
@@ -2737,10 +2648,6 @@ performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
 
-performance-now@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
-
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
@@ -2840,10 +2747,6 @@ punycode@^1.4.1:
 qs@~6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
-
-qs@~6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
 randomatic@^1.1.3:
   version "1.1.7"
@@ -3027,33 +2930,6 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@^2.79.0:
-  version "2.83.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.6.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.1"
-    forever-agent "~0.6.1"
-    form-data "~2.3.1"
-    har-validator "~5.0.3"
-    hawk "~6.0.2"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.17"
-    oauth-sign "~0.8.2"
-    performance-now "^2.1.0"
-    qs "~6.5.1"
-    safe-buffer "^5.1.1"
-    stringstream "~0.0.5"
-    tough-cookie "~2.3.3"
-    tunnel-agent "^0.6.0"
-    uuid "^3.1.0"
-
 require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
@@ -3180,12 +3056,6 @@ sntp@1.x.x:
   dependencies:
     hoek "2.x.x"
 
-sntp@2.x.x:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.1.0.tgz#2c6cec14fedc2222739caf9b5c3d85d1cc5a2cc8"
-  dependencies:
-    hoek "4.x.x"
-
 sort-keys@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-2.0.0.tgz#658535584861ec97d730d6cf41822e1f56684128"
@@ -3306,7 +3176,7 @@ string_decoder@~1.0.3:
   dependencies:
     safe-buffer "~5.1.0"
 
-stringstream@~0.0.4, stringstream@~0.0.5:
+stringstream@~0.0.4:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
@@ -3467,7 +3337,7 @@ to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
-tough-cookie@~2.3.0, tough-cookie@~2.3.3:
+tough-cookie@~2.3.0:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   dependencies:
@@ -3613,7 +3483,7 @@ util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 
-uuid@^3.0.0, uuid@^3.1.0:
+uuid@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,6 +239,10 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argv@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/argv/-/argv-0.0.2.tgz#ecbd16f8949b157183711b1bda334f37840185ab"
+
 arr-diff@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-2.0.0.tgz#8f3b827f955a8bd669697e4a4256ac3ceae356cf"
@@ -968,6 +972,14 @@ code-excerpt@^2.1.0:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+codecov@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/codecov/-/codecov-3.0.0.tgz#c273b8c4f12945723e8dc9d25803d89343e5f28e"
+  dependencies:
+    argv "0.0.2"
+    request "2.81.0"
+    urlgrey "0.4.4"
 
 color-convert@^1.9.0:
   version "1.9.1"
@@ -3592,6 +3604,10 @@ url-parse-lax@^1.0.0:
   resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
   dependencies:
     prepend-http "^1.0.1"
+
+urlgrey@0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/urlgrey/-/urlgrey-0.4.4.tgz#892fe95960805e85519f1cd4389f2cb4cbb7652f"
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Coveralls has pretty bad delays recently.

Codecov allows merging coverage per commit, instead of per build on coveralls. That allows reporting coverage from all CircleCI containers as well as AppVeyor to get a more complete coverage report.